### PR TITLE
Fixed install script and run for Ubuntu LTS

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -23,7 +23,7 @@ __check_version() {
         if [[ "${installed_version[$i]//[aA-zZ]/}" -gt "${supported_version[$i]}" ]]; then
             break
         elif [[ "${installed_version[$i]//[aA-zZ]/}" -lt "${supported_version[$i]}" ]]; then
-            logerr "${cmd} >= $2 is required"
+            logerr "${cmd} >= $2 is required but installed version is: ${3//[aA-zZ]/}"
             exit 1
         fi
     done


### PR DESCRIPTION
- Install script is now using git clone (replacing tar which works differently on different OSs)
- Added support for non-ASCII locale when performing checks for dependencies
- Closes #7 